### PR TITLE
Clarify media_object expires_at field usage

### DIFF
--- a/Docs/brief.md
+++ b/Docs/brief.md
@@ -150,8 +150,12 @@ sequenceDiagram
 * mime (TEXT)
 * size_bytes (INTEGER)
 * created_at (TIMESTAMPTZ)
-vexpires_at (TIMESTAMPTZ)
+* expires_at (TIMESTAMPTZ)
 * job_id (UUID, опционально) — связь с задачей обработки
+
+Поле `expires_at` задаёт срок жизни временной ссылки на медиа-файл: оно заполняется при вызове `POST /api/media/register`,
+используется проверкой доступа в `GET /public/media/{id}`, может продлеваться эндпоинтом `POST /api/media/extend`, а также
+определяет, когда воркер и плановая очистка должны удалить просроченные файлы.
 
 **Конфигурационные файлы**
 Данные о Провайдерах (`Providers`) и их Операциях (`Operations`) будут храниться в статических конфигурационных файлах (например, `providers.json`), чтобы избежать усложнения схемы БД.


### PR DESCRIPTION
## Summary
- correct the media_object table definition to reference the expires_at field
- describe where the expires_at timestamp is used across media endpoints and cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1148abcc883328bc1538abb96af9f