### PR TITLE
contracts: первичные спецификации API

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -1,0 +1,577 @@
+openapi: 3.1.0
+info:
+  title: PhotoChanger Platform API
+  version: 0.1.0
+  description: |
+    Контракт REST API платформы PhotoChanger, включающий ingest-эндпоинт для DSLR Remote Pro
+    и внутренние операции для UI управления слотами, медиа и статистикой. Основан на требованиях
+    из `/Docs/brief.md`. Все защищённые эндпоинты используют JWT-аутентификацию и проверку прав.
+servers:
+  - url: https://api.photochanger.local
+    description: Базовый URL платформы
+security:
+  - bearerAuth: []
+tags:
+  - name: Auth
+    description: Аутентификация и управление сессиями
+  - name: Providers
+    description: Справочник AI-провайдеров
+  - name: Slots
+    description: Управление статическими ingest-слотами
+  - name: Media
+    description: Временное и шаблонное медиа-хранилище
+  - name: Stats
+    description: Метрики и отчёты по слотам
+  - name: Ingest
+    description: Внешний ingest-эндпоинт для DSLR Remote Pro
+  - name: Public
+    description: Публичная раздача временных медиа-ссылок
+paths:
+  /api/login:
+    post:
+      tags: [Auth]
+      summary: Вход пользователя и выдача JWT
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ./schemas/LoginRequest.json
+      responses:
+        '200':
+          description: Успешная аутентификация
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/LoginResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /api/providers:
+    get:
+      tags: [Providers]
+      summary: Получить короткий справочник провайдеров
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Список провайдеров
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/ProviderList.json
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/slots:
+    get:
+      tags: [Slots]
+      summary: Получить список статических ingest-слотов
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: provider_id
+          schema:
+            type: string
+          description: Фильтр по провайдеру
+        - in: query
+          name: operation_id
+          schema:
+            type: string
+          description: Фильтр по операции провайдера
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Поиск по имени слота
+      responses:
+        '200':
+          description: Коллекция слотов
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/SlotListResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/slots/{slot_id}:
+    get:
+      tags: [Slots]
+      summary: Получить данные конкретного слота
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SlotId'
+      responses:
+        '200':
+          description: Данные слота
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/Slot.json
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    put:
+      tags: [Slots]
+      summary: Обновить настройки слота
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SlotId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ./schemas/SlotUpdateRequest.json
+      responses:
+        '200':
+          description: Настройки обновлены
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/SlotUpdateResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/slots/{slot_id}/reset_stats:
+    post:
+      tags: [Slots]
+      summary: Сбросить статистику слота
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SlotId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Пустой объект для совместимости
+      responses:
+        '204':
+          description: Статистика сброшена
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/media/register:
+    post:
+      tags: [Media]
+      summary: Зарегистрировать временное медиа и получить публичную ссылку
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: ./schemas/MediaRegisterRequest.json
+      responses:
+        '201':
+          description: Временный файл зарегистрирован
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/MediaObject.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/media/extend:
+    post:
+      tags: [Media]
+      summary: Продлить срок жизни временного файла
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ./schemas/MediaExtendRequest.json
+      responses:
+        '200':
+          description: TTL продлён
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/MediaObject.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /public/media/{id}:
+    get:
+      tags: [Public]
+      summary: Получить временный файл по публичной ссылке
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: uuid
+            type: string
+          description: Идентификатор media_object
+      responses:
+        '200':
+          description: Бинарное содержимое изображения
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          $ref: '#/components/responses/Gone'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/stats/{slot_id}:
+    get:
+      tags: [Stats]
+      summary: Получить статистику по слоту
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SlotId'
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+          description: Начало диапазона (UTC). Максимальная длительность — 31 день.
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+          description: Конец диапазона (UTC)
+        - in: query
+          name: group_by
+          schema:
+            type: string
+            enum: [hour, day, week]
+            default: day
+          description: Гранулярность агрегации
+      responses:
+        '200':
+          description: Детальная статистика по слоту
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/SlotStatsResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/stats/global:
+    get:
+      tags: [Stats]
+      summary: Получить агрегированную статистику по слотам
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+          description: Начало диапазона (UTC). Максимум 90 дней.
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+          description: Конец диапазона (UTC)
+        - in: query
+          name: group_by
+          schema:
+            type: string
+            enum: [day, week, month]
+            default: week
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+        - in: query
+          name: sort_by
+          schema:
+            type: string
+            enum: [period_start, success, errors, ingest_count, avg_response_ms, p95_response_ms, total_cost]
+            default: period_start
+        - in: query
+          name: sort_order
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - in: query
+          name: provider_id
+          schema:
+            type: string
+          description: Фильтр по провайдеру
+        - in: query
+          name: slot_id
+          schema:
+            type: string
+          description: Фильтр по конкретному слоту
+      responses:
+        '200':
+          description: Агрегированная статистика
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/GlobalStatsResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /ingest/{slotId}:
+    post:
+      tags: [Ingest]
+      summary: Принять ingest-запрос от DSLR Remote Pro
+      description: >-
+        Эндпоинт принимает multipart/form-data с исходной фотографией и глобальным паролем.
+        Дополнительные текстовые поля не валидируются и сохраняются как метаданные. Ограничение
+        ожидания ответа — до 50 секунд.
+      security: []
+      parameters:
+        - in: path
+          name: slotId
+          required: true
+          schema:
+            type: string
+            description: Статический идентификатор ingest-слота (`slot-001` … `slot-015`).
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: ./schemas/IngestRequest.json
+      responses:
+        '200':
+          description: Успешная обработка изображения
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            image/heic:
+              schema:
+                type: string
+                format: binary
+            image/heif:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    SlotId:
+      name: slot_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Идентификатор статического слота (`slot-001` … `slot-015`)
+  responses:
+    BadRequest:
+      description: Некорректный запрос
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    Unauthorized:
+      description: Ошибка аутентификации
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    Forbidden:
+      description: Недостаточно прав
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    NotFound:
+      description: Ресурс не найден
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    Conflict:
+      description: Конфликт состояния
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    UnprocessableEntity:
+      description: Ошибка бизнес-валидации
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    TooManyRequests:
+      description: Превышен лимит запросов
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    PayloadTooLarge:
+      description: Размер файла превышает лимит
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    UnsupportedMediaType:
+      description: MIME не поддерживается
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    InternalError:
+      description: Внутренняя ошибка сервиса
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    ServiceUnavailable:
+      description: Временная недоступность сервиса
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    GatewayTimeout:
+      description: Истекло окно ожидания синхронного ответа
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json
+    Gone:
+      description: Ссылка истекла
+      content:
+        application/json:
+          schema:
+            $ref: ./schemas/Error.json

--- a/contracts/schemas/Error.json
+++ b/contracts/schemas/Error.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ErrorResponse",
+  "type": "object",
+  "required": ["error"],
+  "properties": {
+    "error": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Машиночитаемый код ошибки в snake_case"
+        },
+        "message": {
+          "type": "string",
+          "description": "Человекочитаемое описание проблемы"
+        },
+        "details": {
+          "type": "object",
+          "description": "Дополнительные детали ошибки",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/GlobalStatsMetric.json
+++ b/contracts/schemas/GlobalStatsMetric.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GlobalStatsMetric",
+  "type": "object",
+  "required": [
+    "period_start",
+    "period_end",
+    "success",
+    "timeouts",
+    "provider_errors",
+    "cancelled",
+    "errors",
+    "ingest_count",
+    "avg_response_ms",
+    "p95_response_ms",
+    "total_cost"
+  ],
+  "properties": {
+    "period_start": {
+      "type": "string",
+      "format": "date"
+    },
+    "period_end": {
+      "type": "string",
+      "format": "date"
+    },
+    "success": { "type": "integer", "minimum": 0 },
+    "timeouts": { "type": "integer", "minimum": 0 },
+    "provider_errors": { "type": "integer", "minimum": 0 },
+    "cancelled": { "type": "integer", "minimum": 0 },
+    "errors": { "type": "integer", "minimum": 0 },
+    "ingest_count": { "type": "integer", "minimum": 0 },
+    "avg_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+    "p95_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+    "total_cost": { "type": "number", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/GlobalStatsResponse.json
+++ b/contracts/schemas/GlobalStatsResponse.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GlobalStatsResponse",
+  "type": "object",
+  "required": ["summary", "data", "meta"],
+  "properties": {
+    "summary": {
+      "type": "object",
+      "required": [
+        "total_runs",
+        "timeouts",
+        "provider_errors",
+        "cancelled",
+        "errors",
+        "ingest_count",
+        "avg_response_ms",
+        "p95_response_ms",
+        "error_rate_percent",
+        "total_cost"
+      ],
+      "properties": {
+        "total_runs": { "type": "integer", "minimum": 0 },
+        "timeouts": { "type": "integer", "minimum": 0 },
+        "provider_errors": { "type": "integer", "minimum": 0 },
+        "cancelled": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "ingest_count": { "type": "integer", "minimum": 0 },
+        "avg_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+        "p95_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+        "error_rate_percent": { "type": "number", "minimum": 0 },
+        "total_cost": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "./GlobalStatsMetric.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["page", "page_size", "total"],
+      "properties": {
+        "page": { "type": "integer", "minimum": 1 },
+        "page_size": { "type": "integer", "minimum": 1 },
+        "total": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/IngestRequest.json
+++ b/contracts/schemas/IngestRequest.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "IngestMultipart",
+  "type": "object",
+  "required": ["password", "fileToUpload"],
+  "properties": {
+    "password": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Глобальный пароль ingest, проверяемый на сервере"
+    },
+    "fileToUpload": {
+      "type": "string",
+      "contentEncoding": "binary",
+      "description": "Основной файл изображения"
+    }
+  },
+  "unevaluatedProperties": true
+}

--- a/contracts/schemas/Job.json
+++ b/contracts/schemas/Job.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Job",
+  "type": "object",
+  "required": [
+    "id",
+    "slot_id",
+    "status",
+    "attempt",
+    "max_attempts",
+    "priority",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "slot_id": {
+      "type": "string",
+      "pattern": "^slot-[0-9]{3}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "processing", "completed", "failed_timeout", "failed_provider", "cancelled"]
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "max_attempts": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "priority": {
+      "type": "integer"
+    },
+    "payload_path": {
+      "type": ["string", "null"]
+    },
+    "external_queue_id": {
+      "type": ["string", "null"]
+    },
+    "external_async_id": {
+      "type": ["string", "null"]
+    },
+    "external_metadata": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "locked_by": {
+      "type": ["string", "null"]
+    },
+    "locked_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "last_attempt_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "next_retry_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/LoginRequest.json
+++ b/contracts/schemas/LoginRequest.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LoginRequest",
+  "type": "object",
+  "required": ["username", "password"],
+  "properties": {
+    "username": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Имя предустановленного пользователя"
+    },
+    "password": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Пароль пользователя"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/LoginResponse.json
+++ b/contracts/schemas/LoginResponse.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LoginResponse",
+  "type": "object",
+  "required": ["access_token", "token_type", "expires_in_sec"],
+  "properties": {
+    "access_token": {
+      "type": "string",
+      "description": "JWT токен доступа"
+    },
+    "token_type": {
+      "type": "string",
+      "const": "bearer",
+      "description": "Тип токена"
+    },
+    "expires_in_sec": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Время жизни токена в секундах"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/MediaExtendRequest.json
+++ b/contracts/schemas/MediaExtendRequest.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaExtendRequest",
+  "type": "object",
+  "required": ["id"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Идентификатор media_object"
+    },
+    "ttl_sec": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Желаемый новый TTL в секундах"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/MediaObject.json
+++ b/contracts/schemas/MediaObject.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaObject",
+  "type": "object",
+  "required": ["id", "public_url", "expires_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Идентификатор временного медиа"
+    },
+    "public_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Публичный URL для скачивания"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Момент истечения ссылки"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/MediaRegisterRequest.json
+++ b/contracts/schemas/MediaRegisterRequest.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaRegisterRequest",
+  "type": "object",
+  "required": ["file"],
+  "properties": {
+    "file": {
+      "type": "string",
+      "contentEncoding": "binary",
+      "description": "Изображение JPEG/PNG/WEBP, загружаемое во временное хранилище"
+    },
+    "ttl_sec": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Запрошенный срок жизни ссылки в секундах"
+    },
+    "job_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Идентификатор задачи обработки, к которой привязан файл"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/ProviderConfig.json
+++ b/contracts/schemas/ProviderConfig.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderConfig",
+  "type": "object",
+  "required": ["id", "name", "requires_public_media", "operations"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Идентификатор провайдера"
+    },
+    "name": {
+      "type": "string",
+      "description": "Отображаемое имя провайдера"
+    },
+    "requires_public_media": {
+      "type": "boolean",
+      "description": "Нужно ли публичное медиа-хранилище для операций"
+    },
+    "operations": {
+      "type": "array",
+      "items": {
+        "$ref": "./ProviderOperation.json"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/ProviderList.json
+++ b/contracts/schemas/ProviderList.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderListResponse",
+  "type": "object",
+  "required": ["providers"],
+  "properties": {
+    "providers": {
+      "type": "array",
+      "items": {
+        "$ref": "./ProviderSummary.json"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/ProviderOperation.json
+++ b/contracts/schemas/ProviderOperation.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderOperation",
+  "type": "object",
+  "required": ["id", "name", "needs", "schema_ref"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Идентификатор операции"
+    },
+    "name": {
+      "type": "string",
+      "description": "Отображаемое имя операции"
+    },
+    "needs": {
+      "type": "array",
+      "description": "UI требования к полям (например, prompt, reference_image)",
+      "items": {
+        "type": "string"
+      }
+    },
+    "schema_ref": {
+      "type": "string",
+      "description": "Путь к JSON Schema параметров операции"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/ProviderSummary.json
+++ b/contracts/schemas/ProviderSummary.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderSummary",
+  "type": "object",
+  "required": ["id", "name"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Машиночитаемый идентификатор провайдера"
+    },
+    "name": {
+      "type": "string",
+      "description": "Отображаемое имя провайдера"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/Result.json
+++ b/contracts/schemas/Result.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Result",
+  "type": "object",
+  "required": [
+    "id",
+    "job_id",
+    "storage_path",
+    "mime_type",
+    "size_bytes",
+    "checksum",
+    "expires_at",
+    "created_at"
+  ],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "job_id": { "type": "string", "format": "uuid" },
+    "storage_path": { "type": "string" },
+    "mime_type": { "type": "string" },
+    "size_bytes": { "type": "integer", "minimum": 0 },
+    "checksum": { "type": "string" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "metadata": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/Slot.json
+++ b/contracts/schemas/Slot.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Slot",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "provider_id",
+    "operation_id",
+    "settings_json",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Идентификатор статического ingest-слота",
+      "pattern": "^slot-[0-9]{3}$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Отображаемое имя слота"
+    },
+    "provider_id": {
+      "type": "string",
+      "description": "Идентификатор провайдера"
+    },
+    "operation_id": {
+      "type": "string",
+      "description": "Идентификатор операции провайдера"
+    },
+    "settings_json": {
+      "type": "object",
+      "description": "Параметры, сериализованные для провайдера",
+      "additionalProperties": true
+    },
+    "last_reset_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Метка последнего сброса статистики"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Момент создания слота"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Момент последнего обновления настроек"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/SlotListResponse.json
+++ b/contracts/schemas/SlotListResponse.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SlotListResponse",
+  "type": "object",
+  "required": ["data", "meta"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "./Slot.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["total"],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Количество доступных слотов"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/SlotStatsMetric.json
+++ b/contracts/schemas/SlotStatsMetric.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SlotStatsMetric",
+  "type": "object",
+  "required": [
+    "period_start",
+    "period_end",
+    "success",
+    "timeouts",
+    "provider_errors",
+    "cancelled",
+    "errors",
+    "ingest_count",
+    "avg_response_ms",
+    "p95_response_ms",
+    "total_cost"
+  ],
+  "properties": {
+    "period_start": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "period_end": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "success": { "type": "integer", "minimum": 0 },
+    "timeouts": { "type": "integer", "minimum": 0 },
+    "provider_errors": { "type": "integer", "minimum": 0 },
+    "cancelled": { "type": "integer", "minimum": 0 },
+    "errors": { "type": "integer", "minimum": 0 },
+    "ingest_count": { "type": "integer", "minimum": 0 },
+    "avg_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+    "p95_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+    "total_cost": { "type": "number", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/SlotStatsResponse.json
+++ b/contracts/schemas/SlotStatsResponse.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SlotStatsResponse",
+  "type": "object",
+  "required": ["summary", "metrics"],
+  "properties": {
+    "summary": {
+      "type": "object",
+      "required": [
+        "title",
+        "success",
+        "timeouts",
+        "provider_errors",
+        "cancelled",
+        "errors",
+        "ingest_count",
+        "avg_response_ms",
+        "p95_response_ms",
+        "error_rate_percent",
+        "total_cost"
+      ],
+      "properties": {
+        "title": { "type": ["string", "null"] },
+        "success": { "type": "integer", "minimum": 0 },
+        "timeouts": { "type": "integer", "minimum": 0 },
+        "provider_errors": { "type": "integer", "minimum": 0 },
+        "cancelled": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "ingest_count": { "type": "integer", "minimum": 0 },
+        "avg_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+        "p95_response_ms": { "type": ["integer", "null"], "minimum": 0 },
+        "error_rate_percent": { "type": "number", "minimum": 0 },
+        "last_cost": { "type": ["number", "null"] },
+        "total_cost": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "$ref": "./SlotStatsMetric.json"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/SlotUpdateRequest.json
+++ b/contracts/schemas/SlotUpdateRequest.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SlotUpdateRequest",
+  "type": "object",
+  "required": ["name", "provider_id", "operation_id", "settings_json"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Новое имя слота"
+    },
+    "provider_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Идентификатор провайдера"
+    },
+    "operation_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Идентификатор операции провайдера"
+    },
+    "settings_json": {
+      "type": "object",
+      "description": "Конфигурация операции",
+      "additionalProperties": true
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Текущая версия слота, полученная из последнего чтения"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/SlotUpdateResponse.json
+++ b/contracts/schemas/SlotUpdateResponse.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SlotUpdateResponse",
+  "type": "object",
+  "required": ["id", "updated_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^slot-[0-9]{3}$",
+      "description": "Идентификатор слота"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Новая метка времени обновления"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Цель
- Зафиксировать первичные контракты REST API и базовые доменные схемы согласно SDD-процессу.

## Связанные требования брифа
- Docs/brief.md — разделы «API Спецификация», «Внешний API: Ingest (DSLR Remote Pro)», «Временное публичное медиа-хранилище», «Таблицы Slot/Job/Result».

## Список изменений
- Создан файл `contracts/openapi.yaml` с описанием ключевых эндпоинтов (ingest, login, слоты, медиа, статистика).
- Добавлены JSON Schema для ошибок, слотов, статистики, медиа-объектов, а также доменных сущностей `Job`, `Result`, `ProviderConfig`.

## Чек-лист
- [x] Спецификации соответствуют требованиям брифа.
- [x] Описаны основные коды ответов и ограничения из брифа.
- [ ] Требуются дальнейшие уточнения/расширения (например, схемы конкретных операций провайдеров).

## Тесты
- Не запускались (добавлены только спецификации).

## Скриншоты / логи
- Н/Д (конtrakты).

------
https://chatgpt.com/codex/tasks/task_e_68e3facda9cc8332be3b2b1cd100f429