### PR TITLE
fix: добавить владельца слота в контракт

### DIFF
--- a/spec/contracts/schemas/Slot.json
+++ b/spec/contracts/schemas/Slot.json
@@ -5,6 +5,7 @@
   "required": [
     "id",
     "name",
+    "user_id",
     "provider_id",
     "operation_id",
     "settings_json",
@@ -20,6 +21,10 @@
     "name": {
       "type": "string",
       "description": "Отображаемое имя слота"
+    },
+    "user_id": {
+      "type": ["integer", "null"],
+      "description": "Идентификатор пользователя, за которым закреплён слот"
     },
     "provider_id": {
       "type": "string",

--- a/spec/contracts/schemas/SlotUpdateRequest.json
+++ b/spec/contracts/schemas/SlotUpdateRequest.json
@@ -24,6 +24,10 @@
       "description": "Конфигурация операции",
       "additionalProperties": true
     },
+    "user_id": {
+      "type": ["integer", "null"],
+      "description": "Идентификатор пользователя, которому назначается слот"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time",


### PR DESCRIPTION
## Цель
Синхронизировать контракт `Slot` с брифом, чтобы UI и API могли работать с владельцем слота.

## Ссылка на бриф
- [/Docs/brief.md — раздел «Таблица `Slot`»](Docs/brief.md)

## Изменения
- Добавил поле `user_id` в JSON Schema `Slot.json` как обязательное с поддержкой `null`.
- Расширил `SlotUpdateRequest.json`, чтобы через API можно было назначать или освобождать слот.

## Чек-лист
- [x] Обновлён контракт в соответствии с брифом.
- [ ] Обновлены тесты (не требуются для изменения схемы).

## Тестирование
- Не запускалось (изменения только в спецификациях).

## Скриншоты/Логи
- Н/Д (контракты).


------
https://chatgpt.com/codex/tasks/task_e_68e40e228b908332a1fb73c62d48b965