### PR TITLE
Add template media endpoints to OpenAPI contract

### DIFF
--- a/spec/contracts/openapi.yaml
+++ b/spec/contracts/openapi.yaml
@@ -259,6 +259,84 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalError'
+  /api/template-media/register:
+    post:
+      tags: [Media]
+      summary: Загрузить шаблон и привязать его к слоту
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: ./schemas/TemplateMediaRegisterRequest.json
+      responses:
+        '201':
+          description: Шаблон зарегистрирован и привязан
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/TemplateMediaObject.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/template-media/{id}:
+    delete:
+      tags: [Media]
+      summary: Удалить шаблонное медиа и отвязать от слота
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор шаблонного медиа
+          schema:
+            type: string
+            format: uuid
+        - name: slot_id
+          in: query
+          required: true
+          description: Слот, из которого удаляется привязка
+          schema:
+            type: string
+        - name: setting_key
+          in: query
+          required: true
+          description: Ключ настройки, который ссылался на шаблон
+          schema:
+            type: string
+        - name: force
+          in: query
+          required: false
+          description: Удалить файл даже при нескольких привязках
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: Шаблон удалён или отвязан
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /public/media/{id}:

--- a/spec/contracts/schemas/TemplateMediaObject.json
+++ b/spec/contracts/schemas/TemplateMediaObject.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TemplateMediaObject",
+  "type": "object",
+  "required": ["id", "slot_id", "setting_key", "mime", "size_bytes", "created_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Идентификатор шаблонного медиа"
+    },
+    "slot_id": {
+      "type": "string",
+      "description": "Слот, с которым связана загрузка"
+    },
+    "setting_key": {
+      "type": "string",
+      "description": "Ключ настройки, к которому привязан шаблон"
+    },
+    "label": {
+      "type": ["string", "null"],
+      "description": "Необязательный человекочитаемый ярлык шаблона"
+    },
+    "mime": {
+      "type": "string",
+      "description": "MIME-тип сохранённого файла"
+    },
+    "size_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Размер файла в байтах"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Момент загрузки шаблона"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/TemplateMediaRegisterRequest.json
+++ b/spec/contracts/schemas/TemplateMediaRegisterRequest.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TemplateMediaRegisterRequest",
+  "type": "object",
+  "required": ["file", "slot_id", "setting_key"],
+  "properties": {
+    "file": {
+      "type": "string",
+      "contentEncoding": "binary",
+      "description": "Файл шаблона (JPEG/PNG/WEBP/HEIC/HEIF) для постоянного хранения"
+    },
+    "slot_id": {
+      "type": "string",
+      "description": "Идентификатор слота, к которому привязывается шаблон"
+    },
+    "setting_key": {
+      "type": "string",
+      "description": "Ключ настройки в Slot.settings_json, который ссылается на шаблон"
+    },
+    "label": {
+      "type": "string",
+      "description": "Человекочитаемое название шаблона для UI"
+    },
+    "replace": {
+      "type": "boolean",
+      "description": "Флаг замены существующей привязки шаблона"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- describe POST /api/template-media/register contract covering upload requirements, responses, and errors
- add DELETE /api/template-media/{id} contract including expected parameters and response codes
- document reusable schemas for template media registration payload and response object

## Testing
- not run (spec updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e40f1d808883328a9e3b6ec79c3bb3