### PR TITLE
docs: add global settings and media cache purge contracts

### DIFF
--- a/spec/contracts/openapi.yaml
+++ b/spec/contracts/openapi.yaml
@@ -20,6 +20,8 @@ tags:
     description: Управление статическими ingest-слотами
   - name: Media
     description: Временное и шаблонное медиа-хранилище
+  - name: Settings
+    description: Глобальные настройки платформы и управление секретами
   - name: Stats
     description: Метрики и отчёты по слотам
   - name: Ingest
@@ -189,6 +191,85 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/settings:
+    get:
+      tags: [Settings]
+      summary: Получить глобальные настройки платформы
+      description: Требует право `settings:read`. Возвращает статус секретов и параметры TTL медиахранилища
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Текущие настройки платформы
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/SettingsResponse.json
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    put:
+      tags: [Settings]
+      summary: Обновить глобальные настройки и секреты
+      description: Требует право `settings:write`. Обновляет только переданные поля и возвращает актуальные значения
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ./schemas/SettingsUpdateRequest.json
+      responses:
+        '200':
+          description: Настройки обновлены
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/SettingsResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/media/cache/purge:
+    post:
+      tags: [Settings]
+      summary: Поставить задачу очистки медиа-кеша
+      description: Требует право `settings:write`. Планирует асинхронное удаление устаревших Result и media_object
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: ./schemas/MediaCachePurgeRequest.json
+      responses:
+        '202':
+          description: Очистка поставлена в очередь
+          content:
+            application/json:
+              schema:
+                $ref: ./schemas/MediaCachePurgeResponse.json
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
         '500':
           $ref: '#/components/responses/InternalError'
   /api/media/register:

--- a/spec/contracts/schemas/MediaCachePurgeRequest.json
+++ b/spec/contracts/schemas/MediaCachePurgeRequest.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaCachePurgeRequest",
+  "type": "object",
+  "properties": {
+    "scope": {
+      "type": "string",
+      "enum": ["full", "media_objects"],
+      "description": "Режим очистки: полная (Result + media_object) или только временные media_object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/MediaCachePurgeResponse.json
+++ b/spec/contracts/schemas/MediaCachePurgeResponse.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaCachePurgeResponse",
+  "type": "object",
+  "required": ["status", "scope", "job_id", "expires_cutoff"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["queued_for_gc"],
+      "description": "Статус постановки задания очистки"
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["full", "media_objects"],
+      "description": "Режим, с которым запланирована очистка"
+    },
+    "job_id": {
+      "type": "string",
+      "description": "Идентификатор фонового задания очистки"
+    },
+    "expires_cutoff": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Пороговый момент времени, до которого будут удалены устаревшие сущности"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/MediaCacheSettings.json
+++ b/spec/contracts/schemas/MediaCacheSettings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaCacheSettings",
+  "type": "object",
+  "properties": {
+    "processed_media_ttl_hours": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "maximum": 168,
+      "description": "Срок хранения итоговых Result в часах"
+    },
+    "public_link_default_ttl_sec": {
+      "type": ["integer", "null"],
+      "minimum": 50,
+      "maximum": 86400,
+      "description": "TTL публичных ссылок, выдаваемых по умолчанию, в секундах"
+    },
+    "max_manual_ttl_sec": {
+      "type": ["integer", "null"],
+      "minimum": 50,
+      "description": "Максимальный TTL, который оператор может выставить вручную для media_object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/MediaCacheSettingsUpdate.json
+++ b/spec/contracts/schemas/MediaCacheSettingsUpdate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MediaCacheSettingsUpdate",
+  "type": "object",
+  "properties": {
+    "processed_media_ttl_hours": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 168,
+      "description": "Новое значение TTL итоговых Result в часах"
+    },
+    "public_link_default_ttl_sec": {
+      "type": "integer",
+      "minimum": 50,
+      "maximum": 86400,
+      "description": "Базовый TTL публичных ссылок media_object в секундах"
+    },
+    "max_manual_ttl_sec": {
+      "type": "integer",
+      "minimum": 50,
+      "description": "Максимальный TTL, который оператор может выставить вручную для media_object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/SettingsDslrPasswordStatus.json
+++ b/spec/contracts/schemas/SettingsDslrPasswordStatus.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SettingsDslrPasswordStatus",
+  "type": "object",
+  "required": ["is_set"],
+  "properties": {
+    "is_set": {
+      "type": "boolean",
+      "description": "Признак того, что DSLR-пароль установлен (хэш присутствует в хранилище)"
+    },
+    "updated_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Момент последнего обновления значения либо null, если пароль не задавался"
+    },
+    "updated_by": {
+      "type": ["string", "null"],
+      "description": "Логин пользователя, выполнившего обновление значения"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/SettingsProviderKeyStatus.json
+++ b/spec/contracts/schemas/SettingsProviderKeyStatus.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SettingsProviderKeyStatus",
+  "type": "object",
+  "required": ["is_configured"],
+  "properties": {
+    "is_configured": {
+      "type": "boolean",
+      "description": "Показывает, что секреты и обязательные параметры для провайдера заданы"
+    },
+    "updated_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Момент последнего обновления секрета или null, если значение ещё не задавалось"
+    },
+    "updated_by": {
+      "type": ["string", "null"],
+      "description": "Логин пользователя, обновившего секрет"
+    }
+  },
+  "additionalProperties": {
+    "description": "Дополнительные несекретные поля конфигурации провайдера (например, project_id)",
+    "anyOf": [
+      { "type": "string" },
+      { "type": "number" },
+      { "type": "boolean" }
+    ]
+  }
+}

--- a/spec/contracts/schemas/SettingsProviderKeyUpdate.json
+++ b/spec/contracts/schemas/SettingsProviderKeyUpdate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SettingsProviderKeyUpdate",
+  "type": "object",
+  "properties": {
+    "api_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Новый API-ключ провайдера"
+    }
+  },
+  "additionalProperties": {
+    "description": "Дополнительные параметры конфигурации провайдера (например, project_id)",
+    "anyOf": [
+      { "type": "string" },
+      { "type": "number" },
+      { "type": "boolean" }
+    ]
+  }
+}

--- a/spec/contracts/schemas/SettingsResponse.json
+++ b/spec/contracts/schemas/SettingsResponse.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SettingsResponse",
+  "type": "object",
+  "required": ["dslr_password", "provider_keys", "media_cache"],
+  "properties": {
+    "dslr_password": {
+      "$ref": "./SettingsDslrPasswordStatus.json"
+    },
+    "provider_keys": {
+      "type": "object",
+      "description": "Секреты и публичные параметры AI-провайдеров, индексированные по идентификатору",
+      "additionalProperties": {
+        "$ref": "./SettingsProviderKeyStatus.json"
+      }
+    },
+    "media_cache": {
+      "$ref": "./MediaCacheSettings.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/contracts/schemas/SettingsUpdateRequest.json
+++ b/spec/contracts/schemas/SettingsUpdateRequest.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SettingsUpdateRequest",
+  "type": "object",
+  "properties": {
+    "dslr_password": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Новый пароль, который будет захеширован и сохранён для DSLR Remote Pro"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Секция обновления DSLR-пароля. Передача значения перехеширует пароль"
+    },
+    "provider_keys": {
+      "type": "object",
+      "description": "Карточки провайдеров для обновления секретов и публичных параметров",
+      "additionalProperties": {
+        "$ref": "./SettingsProviderKeyUpdate.json"
+      }
+    },
+    "media_cache": {
+      "$ref": "./MediaCacheSettingsUpdate.json",
+      "description": "Новые значения TTL медиахранилища. Отсутствующие поля не изменяются"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Цель
- Задокументировать в OpenAPI контракты `GET /api/settings`, `PUT /api/settings` и `POST /api/media/cache/purge` согласно требованиям брифа.

## Ссылка на бриф
- `/Docs/brief.md`, раздел «API глобальных настроек и управление секретами».

## Изменения
- Добавлен тег `Settings` и описания эндпоинтов чтения/обновления настроек в `openapi.yaml`.
- Описан контракт очистки медиа-кеша с ответом очереди (`202 Accepted`).
- Созданы JSON Schema для структур настроек, обновления секретов и очереди очистки.

## Чек-лист
- [x] Контракты обновлены в соответствии с брифом.
- [ ] Требуются доработки реализации/тестов (следующие этапы SDD).

## Тесты
- Не запускались (обновление спецификаций).


------
https://chatgpt.com/codex/tasks/task_e_68e4104471b08332a1c43d323a9a0149