### PR TITLE
Добавить last_reset_at в SlotStatsResponse.summary

### DIFF
--- a/spec/contracts/schemas/SlotStatsResponse.json
+++ b/spec/contracts/schemas/SlotStatsResponse.json
@@ -17,6 +17,7 @@
         "avg_response_ms",
         "p95_response_ms",
         "error_rate_percent",
+        "last_reset_at",
         "total_cost"
       ],
       "properties": {
@@ -31,6 +32,10 @@
         "p95_response_ms": { "type": ["integer", "null"], "minimum": 0 },
         "error_rate_percent": { "type": "number", "minimum": 0 },
         "last_cost": { "type": ["number", "null"] },
+        "last_reset_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "total_cost": { "type": "number", "minimum": 0 }
       },
       "additionalProperties": false

--- a/spec/docs/blueprints/test-plan.md
+++ b/spec/docs/blueprints/test-plan.md
@@ -11,6 +11,7 @@
 - **Contract**
   - Проверка соответствия API `POST /ingest/{slotId}`, `/api/media/register`, `/api/media/extend`, `/public/media/{id}` спецификациям (`spec/contracts`).
   - JSON Schema для `Slot`, `Job`, `Result`, `MediaObject`.
+  - Валидация `SlotStatsResponse` — `summary.last_reset_at` присутствует и соответствует формату `date-time`.
 - **Integration**
   - Интеракция API ↔ очередь ↔ воркеры с моками провайдеров.
   - Очистка медиа после финальных статусов; связь Job ↔ Result.


### PR DESCRIPTION
## Summary
- расширил контракт SlotStatsResponse, добавив обязательное поле summary.last_reset_at формата date-time
- обновил тест-план контрактных проверок, чтобы включить проверку наличия и формата summary.last_reset_at

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e412634604833297128e34145d3948