### PR TITLE
Align stats and media schemas with brief

### DIFF
--- a/spec/contracts/schemas/MediaRegisterRequest.json
+++ b/spec/contracts/schemas/MediaRegisterRequest.json
@@ -11,8 +11,9 @@
     },
     "ttl_sec": {
       "type": "integer",
-      "minimum": 1,
-      "description": "Запрошенный срок жизни ссылки в секундах"
+      "minimum": 50,
+      "maximum": 86400,
+      "description": "Запрошенный срок жизни ссылки в секундах (ограничен диапазоном MEDIA_PUBLIC_LINK_DEFAULT_TTL_SEC … media.max_manual_ttl_sec)"
     },
     "job_id": {
       "type": "string",

--- a/spec/contracts/schemas/SlotStatsMetric.json
+++ b/spec/contracts/schemas/SlotStatsMetric.json
@@ -17,12 +17,18 @@
   ],
   "properties": {
     "period_start": {
-      "type": "string",
-      "format": "date-time"
+      "description": "Начало агрегируемого интервала",
+      "anyOf": [
+        { "type": "string", "format": "date-time" },
+        { "type": "string", "format": "date" }
+      ]
     },
     "period_end": {
-      "type": "string",
-      "format": "date-time"
+      "description": "Конец агрегируемого интервала",
+      "anyOf": [
+        { "type": "string", "format": "date-time" },
+        { "type": "string", "format": "date" }
+      ]
     },
     "success": { "type": "integer", "minimum": 0 },
     "timeouts": { "type": "integer", "minimum": 0 },

--- a/spec/contracts/schemas/SlotStatsResponse.json
+++ b/spec/contracts/schemas/SlotStatsResponse.json
@@ -2,8 +2,38 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "SlotStatsResponse",
   "type": "object",
-  "required": ["summary", "metrics"],
+  "required": ["slot_id", "range", "summary", "metrics"],
   "properties": {
+    "slot_id": {
+      "type": "string",
+      "description": "Идентификатор слота, для которого рассчитана статистика"
+    },
+    "range": {
+      "type": "object",
+      "required": ["from", "to", "group_by"],
+      "properties": {
+        "from": {
+          "description": "Начало выбранного диапазона статистики",
+          "anyOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "string", "format": "date" }
+          ]
+        },
+        "to": {
+          "description": "Конец выбранного диапазона статистики",
+          "anyOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "string", "format": "date" }
+          ]
+        },
+        "group_by": {
+          "type": "string",
+          "enum": ["hour", "day", "week"],
+          "description": "Гранулярность агрегирования метрик"
+        }
+      },
+      "additionalProperties": false
+    },
     "summary": {
       "type": "object",
       "required": [
@@ -33,7 +63,7 @@
         "error_rate_percent": { "type": "number", "minimum": 0 },
         "last_cost": { "type": ["number", "null"] },
         "last_reset_at": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time"
         },
         "total_cost": { "type": "number", "minimum": 0 }


### PR DESCRIPTION
## Summary
- add slot identifier and requested range metadata to the slot stats response schema and allow nullable last_reset_at
- relax stats metric timestamps to support date-only aggregation buckets per brief examples
- restrict media register ttl_sec to the documented configuration range

## Testing
- python -m json.tool spec/contracts/schemas/SlotStatsResponse.json
- python -m json.tool spec/contracts/schemas/SlotStatsMetric.json
- python -m json.tool spec/contracts/schemas/MediaRegisterRequest.json

------
https://chatgpt.com/codex/tasks/task_e_68e414c3a9788332bb251600994fa319