### PR TITLE
fix: зафиксировать TTL обработанных медиа

### DIFF
--- a/spec/contracts/schemas/MediaCacheSettings.json
+++ b/spec/contracts/schemas/MediaCacheSettings.json
@@ -4,10 +4,10 @@
   "type": "object",
   "properties": {
     "processed_media_ttl_hours": {
-      "type": ["integer", "null"],
-      "minimum": 1,
-      "maximum": 168,
-      "description": "Срок хранения итоговых Result в часах"
+      "type": "integer",
+      "const": 72,
+      "readOnly": true,
+      "description": "Фиксированный срок хранения итоговых Result в часах"
     },
     "public_link_default_ttl_sec": {
       "type": ["integer", "null"],

--- a/spec/contracts/schemas/MediaCacheSettingsUpdate.json
+++ b/spec/contracts/schemas/MediaCacheSettingsUpdate.json
@@ -3,12 +3,6 @@
   "title": "MediaCacheSettingsUpdate",
   "type": "object",
   "properties": {
-    "processed_media_ttl_hours": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 168,
-      "description": "Новое значение TTL итоговых Result в часах"
-    },
     "public_link_default_ttl_sec": {
       "type": "integer",
       "minimum": 50,

--- a/spec/contracts/schemas/SettingsUpdateRequest.json
+++ b/spec/contracts/schemas/SettingsUpdateRequest.json
@@ -25,7 +25,7 @@
     },
     "media_cache": {
       "$ref": "./MediaCacheSettingsUpdate.json",
-      "description": "Новые значения TTL медиахранилища. Отсутствующие поля не изменяются"
+      "description": "Настройки TTL для временных media_object. Итоговые Result всегда хранятся 72 часа"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- убрал возможность изменять `processed_media_ttl_hours` через контракт настроек
- отметил в `MediaCacheSettings` фиксированное значение TTL 72 часа как read-only
- уточнил описание секции `media_cache`, что итоговые Result всегда хранятся 72 часа

## Testing
- not run (spec change)


------
https://chatgpt.com/codex/tasks/task_e_68e61c3a188883328ef914da7edd65f4